### PR TITLE
fix : 회의록 LLM 키워드 추출 프롬프트 수정, 한글 키워드 -> 영어 키워드 5개 반환

### DIFF
--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -11,11 +11,10 @@ def extract_keywords(text: str) -> KeywordSummaryResult:
     회의록 텍스트로부터 키워드와 요약을 추출 (Gemini API 활용)
     """
     meeting_prompt = f"""
-    다음은 한 연구실의 회의록입니다.  
-    이 회의록의 핵심 연구 키워드 5개 추출해 주세요.  
-    각 키워드는 1~3단어로 간결하게 표현하고, 리스트 형태로 출력해 주세요.
+    The following is a meeting transcript from a research lab.
+    Please extract 5 core research keywords in English, each keyword should be 1-3 words, and output as a list.
 
-    [회의록 입력]
+    [Meeting Transcript]
     ---
     {text}
     ---


### PR DESCRIPTION
1. LLM(Gemini) 키워드 추출 프롬프트를 수정하였습니다. / 한글 -> 영어 수정

2. 실행 결과
<img width="885" alt="스크린샷 2025-05-23 오후 9 32 18" src="https://github.com/user-attachments/assets/904d3e4a-0f11-487d-b406-af5e2fe68202" />
다음과 같이 keywords 구조에 리스트 형태로 잘 표현됩니다. 