### PR TITLE
[FEAT] Celery를 통한 Batch 프로세스 분산처리

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -1,0 +1,21 @@
+from celery import Celery
+
+celery_app = Celery(
+    'dp_project',
+    broker='redis://localhost:6379/0',
+    backend='redis://localhost:6379/1',
+    include=[
+        'app.workers.pdf_worker',
+        'app.workers.llm_worker',
+        'app.workers.invertedindex_worker',
+        'app.workers.openalex_worker',
+        'app.workers.openalex_reduce_worker',
+    ]
+)
+celery_app.conf.task_routes = {
+    'workers.pdf_worker.*': {'queue': 'pdf'},
+    'workers.llm_worker.*': {'queue': 'llm'},
+    'workers.openalex_worker.*': {'queue': 'openalex'},
+    'workers.openalex_reduce_worker.*': {'queue': 'reduce_openalex'},
+    'workers.invertedindex_worker.*': {'queue': 'invertedindex'},
+}

--- a/app/dtos/crawled_paper_dto.py
+++ b/app/dtos/crawled_paper_dto.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 class CrawledPaper(BaseModel):
-    paper_id: int
+    # paper_id: int
     title: str
     thesis_url: str
     text_content: str

--- a/app/dtos/paperItem_dto.py
+++ b/app/dtos/paperItem_dto.py
@@ -16,6 +16,7 @@ class PaperItem(BaseModel):
 
 
 class InferenceRequest(BaseModel):
+    meeting_id: Optional[int] = None # 회의록 아이디
     content: str
 
 

--- a/app/dtos/summarized_paper_dto.py
+++ b/app/dtos/summarized_paper_dto.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 class SummarizedPaper(BaseModel):
-    paper_id: int
+    # paper_id: int
     title: str
     thesis_url: str
     text_content: str

--- a/app/services/crawling_service.py
+++ b/app/services/crawling_service.py
@@ -75,7 +75,7 @@ class CrawlingService:
                         wait_time = 0
                         latest_pdf_path = None
 
-                        while wait_time < 30:
+                        while wait_time < 10:
                             latest_pdf_path = self._find_latest_pdf()
                             if latest_pdf_path and os.path.getsize(latest_pdf_path) > 0:
                                 break
@@ -119,3 +119,71 @@ class CrawlingService:
             return None
         latest_pdf = max(pdf_files, key=os.path.getctime)
         return latest_pdf
+
+    def crawl_single_paper_text(self, paper: PaperItem) -> CrawledPaper:
+        logger.info(f"단일 논문 크롤링 시작: {paper.title}")
+        text_content = None
+        pdf_path = os.path.join(self.download_dir, 'downloaded_paper.pdf')
+        # 기존 파일 삭제
+        if os.path.exists(pdf_path):
+            os.remove(pdf_path)
+        # 1. requests로 PDF 다운로드 시도
+        try:
+            logger.warning(f"논문 '{paper.title}' PDF 직접 다운로드 시도: {paper.pdf_url}")
+            response = self.session.get(paper.pdf_url, timeout=30)
+            response.raise_for_status()
+            with open(pdf_path, "wb") as f:
+                f.write(response.content)
+            logger.warning(f"논문 '{paper.title}' PDF 직접 다운로드 성공")
+            text_content = self._parse_pdf(pdf_path)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 403:
+                logger.warning(f"논문 '{paper.title}' 403 에러 발생, 셀레니움 다운로드 시도")
+                chrome_options = Options()
+                chrome_options.add_experimental_option("prefs", {
+                    "download.default_directory": self.download_dir,
+                    "download.prompt_for_download": False,
+                    "plugins.always_open_pdf_externally": True
+                })
+                chrome_options.add_argument("--no-sandbox")
+                chrome_options.add_argument("--disable-dev-shm-usage")
+                driver = webdriver.Chrome(options=chrome_options)
+                try:
+                    driver.get(paper.pdf_url)
+                    time.sleep(5)
+                    wait_time = 0
+                    latest_pdf_path = None
+                    while wait_time < 10:
+                        latest_pdf_path = self._find_latest_pdf()
+                        if latest_pdf_path and os.path.getsize(latest_pdf_path) > 0:
+                            break
+                        time.sleep(1)
+                        wait_time += 1
+                    latest_pdf_path = self._find_latest_pdf()
+                    if latest_pdf_path and os.path.getsize(latest_pdf_path) > 0:
+                        logger.warning(f"논문 '{paper.title}' PDF 셀레니움 다운로드 성공: {latest_pdf_path}")
+                        text_content = self._parse_pdf(latest_pdf_path)
+                        os.remove(latest_pdf_path)
+                    else:
+                        logger.error(f"논문 '{paper.title}' PDF 셀레니움 다운로드 실패: 파일 없음 또는 크기 0")
+                except Exception as se:
+                    logger.error(f"논문 '{paper.title}' 셀레니움 다운로드 중 예외: {str(se)}")
+                finally:
+                    driver.quit()
+            else:
+                logger.error(f"논문 '{paper.title}' PDF 다운로드 실패: {str(e)}")
+        except Exception as e:
+            logger.error(f"논문 '{paper.title}' PDF 다운로드 중 예외: {str(e)}")
+        # 파일 정리
+        if os.path.exists(pdf_path):
+            os.remove(pdf_path)
+        # CrawledPaper 생성
+        crawled_paper = CrawledPaper(
+            title=paper.title,
+            thesis_url=paper.pdf_url,
+            text_content=text_content or ""
+        )
+        logger.info(f"단일 논문 처리 완료 (텍스트 길이: {len(text_content) if text_content else 0})")
+        print(f"[DEBUG] {crawled_paper.title} | 텍스트 길이: {len(crawled_paper.text_content) if crawled_paper.text_content else 0}")
+        print(f"[DEBUG] 일부 텍스트: {crawled_paper.text_content[:200] if crawled_paper.text_content else 'None'}")
+        return crawled_paper

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -91,7 +91,6 @@ def summarize_papers(papers: List[CrawledPaper]) -> List[SummarizedPaper]:
                 summary = "요약 불가: LLM 예외 발생"
         
         results.append(SummarizedPaper(
-            paper_id=paper.paper_id,
             title=paper.title,
             thesis_url=paper.thesis_url,
             text_content=paper.text_content,

--- a/app/workers/invertedindex_worker.py
+++ b/app/workers/invertedindex_worker.py
@@ -1,0 +1,35 @@
+from app.celery_app import celery_app
+import pymysql
+import logging
+
+logger = logging.getLogger(__name__)
+
+@celery_app.task(name='workers.invertedindex_worker.build_inverted_index')
+def build_and_save_inverted_index(text, meeting_id):
+    logger.info(f"[INVERTED INDEX] 태스크 시작: meeting_id={meeting_id}")
+    # 1. 띄어쓰기 단위로 단어 분리
+    words = text.split()
+    # 2. 모두 소문자로 변환
+    words = [w.lower() for w in words]
+    # 3. 중복 제거 (원하면 set(words) 사용)
+    unique_words = set(words)
+    logger.info(f"[INVERTED INDEX] {len(unique_words)}개 단어 추출 및 중복 제거 완료")
+
+    # 4. MySQL에 저장
+    conn = pymysql.connect(
+        host='localhost',
+        user='janghyunjun',
+        password='Wonjoon1206!',
+        db='ds',
+        charset='utf8mb4'
+    )
+    try:
+        with conn.cursor() as cursor:
+            for word in unique_words:
+                sql = "INSERT INTO inverted_index (paper_word, meeting_id) VALUES (%s, %s)"
+                cursor.execute(sql, (word, meeting_id))
+        conn.commit()
+        logger.info(f"[INVERTED INDEX] DB 저장 완료: {len(unique_words)}개 단어")
+    finally:
+        conn.close()
+        logger.info(f"[INVERTED INDEX] DB 연결 종료")

--- a/app/workers/llm_worker.py
+++ b/app/workers/llm_worker.py
@@ -1,0 +1,35 @@
+from app.celery_app import celery_app
+from app.services.llm_service import summarize_papers
+from app.dtos.crawled_paper_dto import CrawledPaper
+import requests
+import os
+
+@celery_app.task(name='workers.llm_worker.summarize_paper')
+def summarize_paper(title, meeting_id, txt_path, pdf_url):
+    with open(txt_path, 'r', encoding='utf-8') as f:
+        text = f.read()
+    
+    # CrawledPaper 객체 생성
+    paper = CrawledPaper(
+        title=title,
+        thesis_url=pdf_url,
+        text_content=text
+    )
+    
+    # llm_service의 summarize_papers 메서드 사용
+    summarized = summarize_papers([paper])[0]
+    summary = summarized.summary
+    
+    # 스프링 서버에 요약 결과 저장 요청
+    # requests.post(
+    #     'http://localhost:8080/api/save_paper',
+    #     json={'meetingId': meeting_id, 'title': title, 'summary': summary, 'url': pdf_url}
+    # )
+    print(f"[LLM Worker] 논문 요약 결과: meeting_id={meeting_id}, title={title}, summary={summary}, pdf_url={pdf_url}")
+
+    # txt 파일 삭제
+    try:
+        os.remove(txt_path)
+        print(f"[LLM Worker] txt 파일 삭제 완료: {txt_path}")
+    except Exception as e:
+        print(f"[LLM Worker] txt 파일 삭제 실패: {txt_path}, 에러: {e}")

--- a/app/workers/openalex_reduce_worker.py
+++ b/app/workers/openalex_reduce_worker.py
@@ -1,0 +1,45 @@
+from app.celery_app import celery_app
+import redis
+import json
+import logging
+
+redis_client = redis.Redis(host='localhost', port=6379, db=2)
+logger = logging.getLogger(__name__)
+
+@celery_app.task(name='workers.openalex_reduce_worker.reduce')
+def reduce_openalex_results(task_id, total_map_tasks, meeting_id):
+    logger.info(f"[REDUCE] 태스크 시작: task_id={task_id}, total_map_tasks={total_map_tasks}, meeting_id={meeting_id}")
+    # 모든 map 태스크가 끝났는지 확인
+    while int(redis_client.get(f"openalex:{task_id}:done") or 0) < total_map_tasks:
+        logger.info(f"[REDUCE] map 태스크 완료 대기 중... 현재 완료: {redis_client.get(f'openalex:{task_id}:done')} / {total_map_tasks}")
+        import time; time.sleep(0.5)
+
+    # 모든 논문 결과 집계
+    all_results = []
+    for item in redis_client.lrange(f"openalex:{task_id}", 0, -1):
+        all_results.append(json.loads(item))
+    logger.info(f"[REDUCE] 논문 결과 {len(all_results)}개 집계 완료")
+
+    # 논문별 등장 빈도 집계
+    freq = {}
+    paper_info = {}
+    for paper in all_results:
+        title = paper['title']
+        freq[title] = freq.get(title, 0) + 1
+        paper_info[title] = paper
+
+    # 등장 빈도 기준 상위 10개 선정
+    top_titles = sorted(freq, key=lambda x: -freq[x])[:10]
+    top_papers = [paper_info[title] for title in top_titles]
+    logger.info(f"[REDUCE] 상위 10개 논문 선정: {[p['title'] for p in top_papers]}")
+
+    # PDF 워커에 태스크 발행
+    for paper in top_papers:
+        logger.info(f"[REDUCE] PDF 워커에 태스크 발행: {paper['title']}")
+        celery_app.send_task(
+            'workers.pdf_worker.download_and_extract',
+            args=[paper['title'], paper['pdf'], meeting_id]
+        )
+    # 필요시 결과를 Spring 서버 등에도 전달 가능
+    logger.info(f"[REDUCE] 최종 top_papers 반환")
+    return top_papers

--- a/app/workers/openalex_worker.py
+++ b/app/workers/openalex_worker.py
@@ -1,0 +1,17 @@
+from app.celery_app import celery_app
+from app.services.openalex_service import query_openalex
+import redis
+import json
+
+redis_client = redis.Redis(host='localhost', port=6379, db=2)
+
+@celery_app.task(name='workers.openalex_worker.query_papers')
+def query_papers_task(combo, task_id):
+    papers = query_openalex(combo)  # [{title, pdf, ...}, ...]
+    # 각 논문에 combo 정보도 함께 저장 (reduce에서 활용 가능)
+    for paper in papers:
+        paper['combo'] = combo
+        redis_client.rpush(f"openalex:{task_id}", json.dumps(paper))
+    # Reduce 워커에 완료 신호(카운트)도 보낼 수 있음
+    redis_client.incr(f"openalex:{task_id}:done")
+    return True

--- a/app/workers/pdf_worker.py
+++ b/app/workers/pdf_worker.py
@@ -1,0 +1,38 @@
+from app.celery_app import celery_app
+from app.services.crawling_service import CrawlingService
+from app.dtos.paperItem_dto import PaperItem
+from app.celery_app import celery_app
+import os
+
+@celery_app.task(name='workers.pdf_worker.download_and_extract')
+def download_and_extract(title, pdf_url, meeting_id):
+    crawler = CrawlingService()
+
+    # todo PaperItem에서 paper_id 제거
+    paper_item = PaperItem(paper_id=0, title=title, pdf_url=pdf_url, status="success")
+    crawled = crawler.crawl_single_paper_text(paper_item)
+    text = crawled.text_content
+
+    # txt 파일로 저장
+    txt_dir = './papers_txt'
+    os.makedirs(txt_dir, exist_ok=True)
+    txt_path = os.path.join(txt_dir, f'{meeting_id}_{title}.txt')
+    with open(txt_path, 'w', encoding='utf-8') as f:
+        f.write(crawled.text_content)
+
+    # LLM Worker에 이벤트 발행 (title, meeting_id, txt_path)
+    celery_app.send_task('workers.llm_worker.summarize_paper', args=[title, meeting_id, txt_path, pdf_url])
+
+     # 역색인 워커에는 텍스트 자체 전달
+    chunks = chunk_text(text, 2000)
+    for chunk in chunks:
+        celery_app.send_task(
+            'workers.invertedindex_worker.build_inverted_index',
+            args=[chunk, meeting_id]
+        )
+
+def chunk_text(text, chunk_size=2000):
+    return [text[i:i+chunk_size] for i in range(0, len(text), chunk_size)]
+
+
+

--- a/gateway.py
+++ b/gateway.py
@@ -1,0 +1,43 @@
+import uuid
+import itertools
+from flask import Flask, request, jsonify
+from app.services.llm_service import extract_keywords
+from app.celery_app import celery_app
+
+app = Flask(__name__)
+
+@app.route('/api/meeting', methods=['POST'])
+def handle_meeting():
+    data = request.json
+    meeting_text = data['content']
+    meeting_id = data.get('meetingId')
+
+    ks = extract_keywords(meeting_text)
+    keywords = ks.keywords
+
+    combos = []
+    for r in range(2, len(keywords)+1):
+        combos.extend(list(itertools.combinations(keywords, r)))
+
+    task_id = str(uuid.uuid4())
+    for combo in combos:
+        celery_app.send_task(
+            'workers.openalex_worker.query_papers',
+            args=[list(combo), task_id]
+        )
+
+    # Reduce 태스크 비동기 발행
+    celery_app.send_task(
+        'workers.openalex_reduce_worker.reduce',
+        args=[task_id, len(combos), meeting_id]
+    )
+
+    response = {
+        'meetingId': meeting_id,
+        'summary': ks.summary,
+        'keywords': keywords
+    }
+    return jsonify(response)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5001)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+flask==3.0.2
+google-generativeai==0.3.2
+requests==2.31.0
+PyPDF2==3.0.1
+selenium==4.18.1
+python-dotenv==1.0.1
+redis==5.0.1
+celery==5.3.6
+openalex-python==0.1.0
+pydantic==2.6.3 

--- a/run.py
+++ b/run.py
@@ -3,4 +3,4 @@ from app import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    app.run(host="0.0.0.0", port=5001, debug=True)


### PR DESCRIPTION
**기존 동작 방식**
1. **Spring -> Flask** : 회의록 요약 및 관련 논문 요청
2. **Flask** : 동기적으로 키워드 추출 -> openalex를 통한 관련 논문 검색 -> pdf에서 텍스트 추출 -> 텍스트 요약
3. **Flask -> Spring** : 회의록 및 논문 요약본 저장 요청

**분산 처리 도입**
1. **Spring -> Flask** : 회의록 요약 및 관련 논문 요청
2. **Flask Gateway** : 회의록에서 키워드 추출 -> 회의록 openalex_worker에게 논문 검색을 위한 메시지 큐(Redis) 이벤트 발행 -> 동기적으로 Spring에게 회의록 요약본 및 키워드 반환
3. **Openalex worker (MapReduce 알고리즘**) : 키워드 5개 중 2~5개를 조합하여 openalex에 논문 검색 요청 (Map) -> 전체 논문 리스트 중 가장 빈도가 높은 상위 10개의 논문을 pdf_worker에게 다운로드 요청 이벤트 발행 (Reduce)
4. **PDF worker (InvertedIndex 알고리즘)** : PDF를 직접 다운로드 시도, 403 Client 에러 발생 시 Selenium을 통해 우회 다운로드 다운로드 완료 시 -> llm worker에 요약 요청 이벤트 발행 -> invertedindex worker에게 2000자의 chunk 단위로 잘라서 역색인 요청
5. **LLM worker** : PDF Worker가 논문 전문을 저장해둔 txt 파일을 읽어들여 Gemini에 요약 논문 요약 요청 -> Spring에게 DB 저장 요청
6. **InvertedIndex worker** : PDF worker가 보낸 chunk를 역색인 알고리즘 -> Spring 서버가 조회하는 MySQL의 inverted_index 테이블에 저장


**다음과 같이 Task를 모니터링 가능하도록 해두었습니다.**
<img width="1582" alt="스크린샷 2025-05-31 오전 2 03 33" src="https://github.com/user-attachments/assets/069c3593-d6e9-4dbf-83fd-5e34f4fb76f9" />

[Celery 이용 가이드](https://honored-yellowhorn-89c.notion.site/Celery-20376fc828e4805b9b75e0bcb61b99d9?pvs=4)입니다. 아래 모든 커맨드를 각 터미널에 입력하시고 실행시키시면 됩니다. api 요청은 다음 형식에 맞게 보내주세요.
<img width="847" alt="스크린샷 2025-05-31 오전 2 02 40" src="https://github.com/user-attachments/assets/38de847e-d705-4197-83d4-e5038ed16ba3" />