### PR TITLE
[FEAT] 단일 서버와 분산 서버 벤치마킹

### DIFF
--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -1,5 +1,13 @@
 from celery import Celery
+import logging
 
+# 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format='[%(asctime)s: %(levelname)s/%(processName)s] %(message)s',
+)
+
+# Celery 앱 설정
 celery_app = Celery(
     'dp_project',
     broker='redis://localhost:6379/0',
@@ -12,6 +20,21 @@ celery_app = Celery(
         'app.workers.openalex_reduce_worker',
     ]
 )
+
+# Celery 설정
+celery_app.conf.update(
+    broker_url='redis://localhost:6379/0',
+    result_backend='redis://localhost:6379/1',
+    task_serializer='json',
+    accept_content=['json'],
+    result_serializer='json',
+    timezone='Asia/Seoul',
+    enable_utc=True,
+    worker_log_format='[%(asctime)s: %(levelname)s/%(processName)s] %(message)s',
+    worker_task_log_format='[%(asctime)s: %(levelname)s/%(processName)s] %(message)s',
+    worker_log_level='INFO'
+)
+
 celery_app.conf.task_routes = {
     'workers.pdf_worker.*': {'queue': 'pdf'},
     'workers.llm_worker.*': {'queue': 'llm'},

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -18,6 +18,7 @@ celery_app = Celery(
         'app.workers.invertedindex_worker',
         'app.workers.openalex_worker',
         'app.workers.openalex_reduce_worker',
+        'app.workers.relevance_worker',
     ]
 )
 
@@ -41,4 +42,5 @@ celery_app.conf.task_routes = {
     'workers.openalex_worker.*': {'queue': 'openalex'},
     'workers.openalex_reduce_worker.*': {'queue': 'reduce_openalex'},
     'workers.invertedindex_worker.*': {'queue': 'invertedindex'},
+    'workers.relevance_worker.*': {'queue': 'relevance'},
 }

--- a/app/services/crawling_service.py
+++ b/app/services/crawling_service.py
@@ -163,20 +163,36 @@ class CrawlingService:
                     if latest_pdf_path and os.path.getsize(latest_pdf_path) > 0:
                         logger.warning(f"논문 '{paper.title}' PDF 셀레니움 다운로드 성공: {latest_pdf_path}")
                         text_content = self._parse_pdf(latest_pdf_path)
-                        os.remove(latest_pdf_path)
+                        # PDF 파일 삭제
+                        try:
+                            os.remove(latest_pdf_path)
+                            logger.info(f"PDF 파일 삭제 완료: {latest_pdf_path}")
+                        except Exception as e:
+                            logger.error(f"PDF 파일 삭제 실패: {str(e)}")
                     else:
                         logger.error(f"논문 '{paper.title}' PDF 셀레니움 다운로드 실패: 파일 없음 또는 크기 0")
                 except Exception as se:
                     logger.error(f"논문 '{paper.title}' 셀레니움 다운로드 중 예외: {str(se)}")
                 finally:
                     driver.quit()
+                    # 셀레니움 다운로드 디렉토리의 모든 PDF 파일 삭제
+                    for pdf_file in glob.glob(os.path.join(self.download_dir, '*.pdf')):
+                        try:
+                            os.remove(pdf_file)
+                            logger.info(f"남은 PDF 파일 삭제 완료: {pdf_file}")
+                        except Exception as e:
+                            logger.error(f"PDF 파일 삭제 실패: {str(e)}")
             else:
                 logger.error(f"논문 '{paper.title}' PDF 다운로드 실패: {str(e)}")
         except Exception as e:
             logger.error(f"논문 '{paper.title}' PDF 다운로드 중 예외: {str(e)}")
         # 파일 정리
         if os.path.exists(pdf_path):
-            os.remove(pdf_path)
+            try:
+                os.remove(pdf_path)
+                logger.info(f"임시 PDF 파일 삭제 완료: {pdf_path}")
+            except Exception as e:
+                logger.error(f"임시 PDF 파일 삭제 실패: {str(e)}")
         # CrawledPaper 생성
         crawled_paper = CrawledPaper(
             title=paper.title,

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -154,3 +154,17 @@ def summarize_papers(papers: List[CrawledPaper]) -> List[SummarizedPaper]:
             summary=summary
         ))
     return results
+
+def translate_to_english(text: str) -> str:
+    """
+    한글 회의록을 영어로 번역
+    """
+    prompt = f"""
+    다음 한글 텍스트를 자연스러운 영어로 번역해 주세요. 불필요한 설명 없이 번역문만 출력하세요.
+    
+    [한글 텍스트]
+    ---
+    {text}
+    ---
+    """
+    return call_gemini_with_retry(prompt)

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,10 +1,77 @@
 import google.generativeai as genai
-genai.configure(api_key="AIzaSyAY3DtZzT-9yIJtoIwMP3_iFhGmNN6TlY0")
+import os
 from typing import List
 from app.dtos.crawled_paper_dto import CrawledPaper
 from app.dtos.keyword_summary_dto import KeywordSummaryResult
 from app.dtos.summarized_paper_dto import SummarizedPaper
+from google.api_core.exceptions import ResourceExhausted
+import time
+import random
 
+# Gemini API 토큰 리스트
+GEMINI_API_KEYS = [
+    os.getenv('GEMINI_API_KEY_1'),
+    os.getenv('GEMINI_API_KEY_2'),
+    os.getenv('GEMINI_API_KEY_3')
+]
+
+# None이 아닌 토큰만 필터링
+GEMINI_API_KEYS = [key for key in GEMINI_API_KEYS if key]
+
+if not GEMINI_API_KEYS:
+    raise ValueError("환경변수에 Gemini API 토큰이 설정되지 않았습니다. .env 파일을 확인해주세요.")
+
+# 토큰 사용 횟수를 추적하는 딕셔너리
+token_usage = {key: 0 for key in GEMINI_API_KEYS}
+
+def get_next_token() -> str:
+    """사용 가능한 다음 토큰을 반환"""
+    if not token_usage:
+        raise Exception("사용 가능한 Gemini API 토큰이 없습니다.")
+    
+    # 가장 적게 사용된 토큰 선택
+    min_usage = min(token_usage.values())
+    available_tokens = [key for key, usage in token_usage.items() if usage == min_usage]
+    return random.choice(available_tokens)
+
+def configure_gemini(token: str):
+    """Gemini API 설정"""
+    genai.configure(api_key=token)
+
+def call_gemini_with_retry(prompt: str, max_retries: int = 3) -> str:
+    """여러 토큰을 사용하여 Gemini API 호출"""
+    retries = 0
+    last_error = None
+    
+    while retries < max_retries:
+        try:
+            # 다음 사용할 토큰 선택
+            token = get_next_token()
+            configure_gemini(token)
+            
+            # Gemini API 호출
+            model = genai.GenerativeModel("gemini-1.5-flash")
+            response = model.generate_content(prompt)
+            
+            # 성공 시 토큰 사용 횟수 증가
+            token_usage[token] += 1
+            return response.text.strip()
+            
+        except ResourceExhausted as e:
+            last_error = e
+            print(f"[LLM Service] 토큰 {token} 할당량 초과. 다른 토큰으로 재시도...")
+            # 실패한 토큰의 사용 횟수를 최대로 설정하여 우선순위 낮춤
+            token_usage[token] = max(token_usage.values()) + 1
+            retries += 1
+            time.sleep(2)  # API 제한 회복을 위한 대기
+            
+        except Exception as e:
+            last_error = e
+            print(f"[LLM Service] 예상치 못한 에러 발생: {str(e)}")
+            retries += 1
+            time.sleep(2)
+    
+    raise Exception(f"최대 재시도 횟수 초과. 마지막 에러: {str(last_error)}")
 
 def extract_keywords(text: str) -> KeywordSummaryResult:
     """
@@ -22,19 +89,17 @@ def extract_keywords(text: str) -> KeywordSummaryResult:
     {text}
     ---
     """
-    model = genai.GenerativeModel("gemini-1.5-flash")
-    response = model.generate_content(meeting_prompt)
-    # Gemini 응답에서 키워드 리스트 추출 (예: ['키워드1', '키워드2', ...])
+    
+    # 키워드 추출
+    keywords_text = call_gemini_with_retry(meeting_prompt)
     keywords = []
-    for line in response.text.strip().splitlines():
+    for line in keywords_text.splitlines():
         kw = line.strip("-•* ")
         if kw:
             keywords.append(kw)
     keywords = keywords[:5]
 
-    # #발표용 키워드
-    # keywords = ["Big Data", "Lamda Architecture", "Hadoop"]
-
+    # 요약 추출
     summary_prompt = f"""
     다음은 한 연구실의 회의록입니다.
     이 회의록의 주요 논의 내용을 3~4문장으로 자연스럽게 요약해 주세요.
@@ -44,8 +109,7 @@ def extract_keywords(text: str) -> KeywordSummaryResult:
     {text}
     ---
     """
-    summary_response = model.generate_content(summary_prompt)
-    summary = summary_response.text.strip()
+    summary = call_gemini_with_retry(summary_prompt)
 
     return KeywordSummaryResult(
         summary=summary,
@@ -57,7 +121,6 @@ def summarize_papers(papers: List[CrawledPaper]) -> List[SummarizedPaper]:
     크롤링된 논문 리스트에 대해 요약을 추가한 SummarizedPaper 리스트 반환 (Gemini API 활용)
     """
     results = []
-    model = genai.GenerativeModel("gemini-1.5-flash")
     for paper in papers:
         text = paper.text_content
         print(f"[LLM] {paper.title} | 텍스트 길이: {len(text) if text else 0}")
@@ -67,11 +130,6 @@ def summarize_papers(papers: List[CrawledPaper]) -> List[SummarizedPaper]:
             print(f"[LLM] {paper.title} | 텍스트가 비어있거나 너무 짧음")
             summary = "크롤링에 실패하였습니다. url에 직접 접속해서 논문을 확인해주세요."
         else:
-            # 너무 길면 앞부분만 사용
-            # if len(text) > 15000:
-            #     print(f"[LLM] {paper.title} | 텍스트가 너무 길어 앞 15000자만 사용")
-            #     text = text[:15000]
-            
             paper_prompt = f"""
             다음 논문의 핵심 내용을 10~12문장 이내로 요약해 주세요.  
             논문이 해결하고자 한 문제, 제안한 방법, 실험 결과를 중심으로 간결하게 서술해 주세요.
@@ -83,8 +141,7 @@ def summarize_papers(papers: List[CrawledPaper]) -> List[SummarizedPaper]:
             """
             try:
                 print(f"[LLM] {paper.title} | Gemini API 호출 시작")
-                response = model.generate_content(paper_prompt)
-                summary = response.text.strip()
+                summary = call_gemini_with_retry(paper_prompt)
                 print(f"[LLM] {paper.title} | Gemini API 호출 성공")
             except Exception as e:
                 print(f"[LLM] {paper.title} | 요약 중 예외: {e}")

--- a/app/workers/llm_worker.py
+++ b/app/workers/llm_worker.py
@@ -3,33 +3,71 @@ from app.services.llm_service import summarize_papers
 from app.dtos.crawled_paper_dto import CrawledPaper
 import requests
 import os
+import redis
+import json
+import logging
+
+# 로거 설정
+logger = logging.getLogger('celery.task')
+
+# Redis 연결
+redis_client = redis.Redis(host='localhost', port=6379, db=0)
 
 @celery_app.task(name='workers.llm_worker.summarize_paper')
 def summarize_paper(title, meeting_id, txt_path, pdf_url):
-    with open(txt_path, 'r', encoding='utf-8') as f:
-        text = f.read()
+    logger.info(f"[LLM Worker] 논문 요약 시작: {title}")
     
-    # CrawledPaper 객체 생성
-    paper = CrawledPaper(
-        title=title,
-        thesis_url=pdf_url,
-        text_content=text
-    )
-    
-    # llm_service의 summarize_papers 메서드 사용
-    summarized = summarize_papers([paper])[0]
-    summary = summarized.summary
-    
-    # 스프링 서버에 요약 결과 저장 요청
-    # requests.post(
-    #     'http://localhost:8080/api/save_paper',
-    #     json={'meetingId': meeting_id, 'title': title, 'summary': summary, 'url': pdf_url}
-    # )
-    print(f"[LLM Worker] 논문 요약 결과: meeting_id={meeting_id}, title={title}, summary={summary}, pdf_url={pdf_url}")
-
-    # txt 파일 삭제
     try:
-        os.remove(txt_path)
-        print(f"[LLM Worker] txt 파일 삭제 완료: {txt_path}")
+        with open(txt_path, 'r', encoding='utf-8') as f:
+            text = f.read()
+        
+        # CrawledPaper 객체 생성
+        paper = CrawledPaper(
+            title=title,
+            thesis_url=pdf_url,
+            text_content=text
+        )
+        
+        # llm_service의 summarize_papers 메서드 사용
+        summarized = summarize_papers([paper])[0]
+        summary = summarized.summary
+        
+        # 스프링 서버에 요약 결과 저장 요청
+        try:
+            response = requests.post(
+                'http://localhost:8080/api/save_paper',
+                json={'meetingId': meeting_id, 'title': title, 'summary': summary, 'url': pdf_url}
+            )
+            response.raise_for_status()
+            logger.info(f"[LLM Worker] 논문 요약 결과 저장 완료: meeting_id={meeting_id}, title={title}")
+        except Exception as e:
+            logger.error(f"[LLM Worker] 논문 요약 결과 저장 실패: {str(e)}")
+
+        # Redis에 결과 발행
+        try:
+            result = {
+                'type': 'papers_completed',
+                'meetingId': meeting_id,
+                'paper': {
+                    'title': title,
+                    'summary': summary,
+                    'url': pdf_url
+                }
+            }
+            redis_client.publish('benchmark_results', json.dumps(result))
+            logger.info(f"[LLM Worker] Redis에 결과 발행 완료: {title}")
+        except Exception as e:
+            logger.error(f"[LLM Worker] Redis 결과 발행 실패: {str(e)}")
+
+        # txt 파일 삭제
+        try:
+            os.remove(txt_path)
+            logger.info(f"[LLM Worker] txt 파일 삭제 완료: {txt_path}")
+        except Exception as e:
+            logger.error(f"[LLM Worker] txt 파일 삭제 실패: {txt_path}, 에러: {e}")
+        
+        logger.info(f"[LLM Worker] 논문 요약 작업 완료: {title}")
+        
     except Exception as e:
-        print(f"[LLM Worker] txt 파일 삭제 실패: {txt_path}, 에러: {e}")
+        logger.error(f"[LLM Worker] 논문 요약 중 예외 발생: {str(e)}")
+        raise

--- a/app/workers/pdf_worker.py
+++ b/app/workers/pdf_worker.py
@@ -40,16 +40,6 @@ def download_and_extract(title, pdf_url, meeting_id, meeting_text):
         args=[meeting_id, meeting_text]
     )
 
-    # 역색인 워커에는 텍스트 자체 전달
-    chunks = chunk_text(text, 2000)
-    for chunk in chunks:
-        celery_app.send_task(
-            'workers.invertedindex_worker.build_inverted_index',
-            args=[chunk, meeting_id]
-        )
-
-def chunk_text(text, chunk_size=2000):
-    return [text[i:i+chunk_size] for i in range(0, len(text), chunk_size)]
 
 
 

--- a/app/workers/pdf_worker.py
+++ b/app/workers/pdf_worker.py
@@ -3,9 +3,13 @@ from app.services.crawling_service import CrawlingService
 from app.dtos.paperItem_dto import PaperItem
 from app.celery_app import celery_app
 import os
+import redis
+import json
+
+redis_client = redis.Redis(host='localhost', port=6379, db=3)
 
 @celery_app.task(name='workers.pdf_worker.download_and_extract')
-def download_and_extract(title, pdf_url, meeting_id):
+def download_and_extract(title, pdf_url, meeting_id, meeting_text):
     crawler = CrawlingService()
 
     # todo PaperItem에서 paper_id 제거
@@ -20,10 +24,23 @@ def download_and_extract(title, pdf_url, meeting_id):
     with open(txt_path, 'w', encoding='utf-8') as f:
         f.write(crawled.text_content)
 
-    # LLM Worker에 이벤트 발행 (title, meeting_id, txt_path)
-    celery_app.send_task('workers.llm_worker.summarize_paper', args=[title, meeting_id, txt_path, pdf_url])
+    # Redis에 논문 정보 push
+    paper_info = {
+        'title': title,
+        'txt_path': txt_path,
+        'text_content': crawled.text_content,
+        'meeting_id': meeting_id,
+        'pdf_url': pdf_url
+    }
+    redis_client.rpush(f"relevance:{meeting_id}:papers", json.dumps(paper_info))
 
-     # 역색인 워커에는 텍스트 자체 전달
+    # relevance_worker에 태스크 발행 (논문 1개 도착 알림)
+    celery_app.send_task(
+        'workers.relevance_worker.check_and_select',
+        args=[meeting_id, meeting_text]
+    )
+
+    # 역색인 워커에는 텍스트 자체 전달
     chunks = chunk_text(text, 2000)
     for chunk in chunks:
         celery_app.send_task(

--- a/app/workers/relevance_worker.py
+++ b/app/workers/relevance_worker.py
@@ -1,0 +1,107 @@
+from app.celery_app import celery_app
+import redis
+import json
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+from concurrent.futures import ThreadPoolExecutor
+import numpy as np
+import os
+
+redis_client = redis.Redis(host='localhost', port=6379, db=3)
+
+def delete_txt_file(txt_path):
+    """txt 파일 삭제"""
+    try:
+        if os.path.exists(txt_path):
+            os.remove(txt_path)
+    except Exception as e:
+        print(f"파일 삭제 중 에러 발생: {str(e)}")
+
+def process_paper_batch(papers_batch, meeting_text):
+    texts = [meeting_text] + [p['text_content'] for p in papers_batch]
+    vectorizer = TfidfVectorizer(stop_words='english')
+    tfidf_matrix = vectorizer.fit_transform(texts)
+    similarities = cosine_similarity(tfidf_matrix[0:1], tfidf_matrix[1:])[0]
+    return similarities
+
+@celery_app.task(name='workers.relevance_worker.check_and_select')
+def check_and_select(meeting_id, meeting_text):
+    # Redis에서 논문 리스트 가져오기
+    paper_jsons = redis_client.lrange(f"relevance:{meeting_id}:papers", 0, -1)
+    if len(paper_jsons) < 5:  # 5개 미만이면 대기
+        return
+
+    # 누적된 논문 가져오기
+    accumulated_papers = []
+    accumulated_key = f"relevance:{meeting_id}:accumulated"
+    accumulated_jsons = redis_client.lrange(accumulated_key, 0, -1)
+    if accumulated_jsons:
+        accumulated_papers = [json.loads(p) for p in accumulated_jsons]
+
+    # 현재 배치의 논문
+    current_papers = [json.loads(p) for p in paper_jsons]
+    
+    # 모든 논문 합치기 (누적 + 현재)
+    all_papers = accumulated_papers + current_papers
+    
+    # 병렬 처리를 위한 배치 분할
+    batch_size = 2  # 각 스레드가 처리할 논문 수
+    paper_batches = [all_papers[i:i + batch_size] for i in range(0, len(all_papers), batch_size)]
+    
+    # ThreadPoolExecutor로 병렬 처리
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        batch_similarities = list(executor.map(
+            lambda batch: process_paper_batch(batch, meeting_text),
+            paper_batches
+        ))
+    
+    # 모든 배치의 유사도 결과 병합
+    all_similarities = np.concatenate(batch_similarities)
+    
+    # 상위 3개 논문 선택
+    top_indices = all_similarities.argsort()[::-1][:3]
+    
+    # 선택된 논문과 누적될 논문 분리
+    selected_papers = []
+    remaining_papers = []
+    
+    for i, paper in enumerate(all_papers):
+        if i in top_indices:
+            selected_papers.append(paper)
+        else:
+            remaining_papers.append(paper)
+    
+    # 선택된 논문을 llm_worker에 전송
+    for paper in selected_papers:
+        celery_app.send_task(
+            'workers.llm_worker.summarize_paper',
+            args=[paper['title'], paper['meeting_id'], paper['txt_path'], paper.get('pdf_url', '')]
+        )
+    
+    # 처리된 논문 제거
+    for paper_json in paper_jsons:
+        redis_client.lrem(f"relevance:{meeting_id}:papers", 0, paper_json)
+    
+    # 누적 논문 업데이트
+    redis_client.delete(accumulated_key)  # 기존 누적 논문 삭제
+    if remaining_papers:  # 남은 논문이 있으면 누적
+        for paper in remaining_papers:
+            redis_client.rpush(accumulated_key, json.dumps(paper))
+    
+    # 남은 논문이 5개 이상이면 다시 처리
+    if len(redis_client.lrange(f"relevance:{meeting_id}:papers", 0, -1)) >= 5:
+        celery_app.send_task(
+            'workers.relevance_worker.check_and_select',
+            args=[meeting_id, meeting_text]
+        )
+    else:
+        # 20개의 논문이 모두 처리되었을 때
+        # 누적된 논문들의 txt 파일 삭제
+        accumulated_jsons = redis_client.lrange(accumulated_key, 0, -1)
+        if accumulated_jsons:
+            for paper_json in accumulated_jsons:
+                paper = json.loads(paper_json)
+                if 'txt_path' in paper:
+                    delete_txt_file(paper['txt_path'])
+            # 누적된 논문 리스트도 삭제
+            redis_client.delete(accumulated_key)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,339 @@
+import requests
+import time
+import json
+from datetime import datetime
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+import numpy as np
+from typing import Tuple, List, Dict
+import redis
+import threading
+import queue
+import matplotlib
+matplotlib.rc('font', family='AppleGothic')  # macOS의 경우
+plt.rcParams['axes.unicode_minus'] = False   # 마이너스 깨짐 방지
+
+# 결과를 저장할 큐
+result_queue = queue.Queue()
+
+# Redis 연결
+redis_client = redis.Redis(host='localhost', port=6379, db=0)
+
+def on_message_received(message):
+    """메시지 수신 콜백"""
+    try:
+        data = json.loads(message['data'])
+        if data.get('type') == 'papers_completed':
+            result_queue.put(data)
+    except Exception as e:
+        print(f"메시지 처리 중 에러 발생: {str(e)}")
+
+def setup_redis_subscriber():
+    """Redis 구독자 설정"""
+    pubsub = redis_client.pubsub()
+    pubsub.subscribe('benchmark_results')
+    return pubsub
+
+def calculate_relevance(meeting_text, papers):
+    """회의록과 논문 간의 관련도 계산"""
+    # TF-IDF 벡터화
+    vectorizer = TfidfVectorizer(stop_words='english')
+    
+    # 회의록과 논문 텍스트를 하나의 리스트로 결합
+    texts = [meeting_text] + [paper['summary'] for paper in papers]
+    
+    # TF-IDF 행렬 생성
+    tfidf_matrix = vectorizer.fit_transform(texts)
+    
+    # 회의록과 각 논문 간의 코사인 유사도 계산
+    similarities = cosine_similarity(tfidf_matrix[0:1], tfidf_matrix[1:])
+    
+    # 키워드 매칭 점수 계산
+    meeting_keywords = set(meeting_text.lower().split())
+    keyword_scores = []
+    
+    for paper in papers:
+        paper_keywords = set(paper['summary'].lower().split())
+        common_keywords = meeting_keywords.intersection(paper_keywords)
+        keyword_score = len(common_keywords) / len(meeting_keywords) if meeting_keywords else 0
+        keyword_scores.append(keyword_score)
+    
+    # 최종 관련도 점수 계산 (코사인 유사도와 키워드 매칭 점수의 가중 평균)
+    final_scores = 0.7 * similarities[0] + 0.3 * np.array(keyword_scores)
+    
+    return final_scores
+
+def test_single_server(meeting_text, meeting_id=None):
+    """단일 서버 API 테스트"""
+    start_time = time.time()
+    
+    # API 요청
+    response = requests.post(
+        'http://localhost:5002/api/papers/inference',
+        json={'content': meeting_text, 'meetingId': meeting_id}
+    )
+    
+    end_time = time.time()
+    duration = end_time - start_time
+    
+    if response.status_code == 200:
+        result = response.json()
+        papers = result['recommendedPapers']
+        
+        # 관련도 계산
+        relevance_scores = calculate_relevance(meeting_text, papers)
+        
+        return {
+            'duration': duration,
+            'keywords': result['keywords'],
+            'summary': result['summary'],
+            'papers_count': len(papers),
+            'papers': papers,
+            'relevance_scores': relevance_scores.tolist()
+        }
+    else:
+        raise Exception(f"API 요청 실패: {response.status_code}")
+
+def test_distributed_server(meeting_text: str, meeting_id: int = None) -> Tuple[float, List[str], str, str, List[Dict], List[float]]:
+    """분산 서버 API 테스트"""
+    start_time = time.time()
+    
+    # 최대 3번까지 재시도
+    max_retries = 3
+    retry_delay = 5  # 재시도 간 대기 시간 (초)
+    
+    for attempt in range(max_retries):
+        try:
+            # 초기 요청
+            response = requests.post(
+                'http://localhost:5001/api/papers/inference',
+                json={'content': meeting_text, 'meetingId': meeting_id},
+                timeout=300  # 5분 타임아웃
+            )
+            response.raise_for_status()
+            data = response.json()
+            
+            # 초기 응답 시간
+            initial_duration = time.time() - start_time
+            print(f"초기 응답 시간: {initial_duration:.2f}초")
+            
+            # Redis에서 결과 대기
+            max_wait_time = 300  # 최대 5분 대기
+            start_wait = time.time()
+            processed_papers = []
+            
+            while time.time() - start_wait < max_wait_time:
+                try:
+                    # 큐에서 결과 확인 (1초 타임아웃)
+                    result_data = result_queue.get(timeout=1)
+                    if result_data.get('meetingId') == meeting_id:
+                        paper = result_data.get('paper', {})
+                        if paper:
+                            processed_papers.append(paper)
+                            print(f"논문 처리 완료 ({len(processed_papers)}/10): {paper.get('title', '')}")
+                            
+                            # 모든 논문이 처리되었는지 확인
+                            if len(processed_papers) >= 10:
+                                # 관련도 계산
+                                relevance_scores = calculate_relevance(meeting_text, processed_papers)
+                                total_duration = time.time() - start_time
+                                
+                                return (
+                                    total_duration,
+                                    data.get('keywords', []),
+                                    data.get('summary', ''),
+                                    data.get('meetingId', ''),
+                                    processed_papers,
+                                    relevance_scores.tolist()
+                                )
+                except queue.Empty:
+                    continue
+            
+            raise Exception(f"논문 처리 시간 초과 (처리된 논문: {len(processed_papers)}/10)")
+            
+        except requests.exceptions.RequestException as e:
+            if attempt < max_retries - 1:
+                print(f"요청 실패 (시도 {attempt + 1}/{max_retries}): {str(e)}")
+                print(f"{retry_delay}초 후 재시도...")
+                time.sleep(retry_delay)
+            else:
+                raise Exception(f"최대 재시도 횟수 초과. 마지막 에러: {str(e)}")
+
+def run_benchmark(meeting_text, meeting_id=None, num_runs=5):
+    """벤치마크 실행"""
+    # Redis 구독자 설정
+    pubsub = setup_redis_subscriber()
+    
+    # 구독자 스레드 시작
+    def listen_for_messages():
+        for message in pubsub.listen():
+            if message['type'] == 'message':
+                on_message_received(message)
+    
+    consumer_thread = threading.Thread(target=listen_for_messages)
+    consumer_thread.daemon = True
+    consumer_thread.start()
+    
+    results = {
+        'single': [],
+        'distributed': []
+    }
+    
+    print(f"\n=== 벤치마크 시작 (총 {num_runs}회 실행) ===")
+    
+    try:
+        for i in range(num_runs):
+            print(f"\n실행 {i+1}/{num_runs}")
+
+            # 분산 서버 테스트
+            print("분산 서버 테스트 중...")
+            dist_result = test_distributed_server(meeting_text, meeting_id)
+            results['distributed'].append({
+                'duration': dist_result[0],
+                'keywords': dist_result[1],
+                'summary': dist_result[2],
+                'meeting_id': dist_result[3],
+                'papers': dist_result[4],
+                'relevance_scores': dist_result[5]
+            })
+            print(f"완료 시간: {dist_result[0]:.2f}초")
+            
+            # 단일 서버 테스트
+            print("단일 서버 테스트 중...")
+            single_result = test_single_server(meeting_text, meeting_id)
+            results['single'].append(single_result)
+            print(f"완료 시간: {single_result['duration']:.2f}초")
+            
+            
+            # 결과를 파일로 저장
+            save_benchmark_result(meeting_id, i+1, single_result, dist_result)
+    
+    finally:
+        # Redis 구독 해제
+        pubsub.unsubscribe()
+    
+    return results
+
+def save_benchmark_result(meeting_id, run_number, single_result, dist_result):
+    """벤치마크 결과를 파일로 저장"""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = f"benchmark_results_{meeting_id}_{timestamp}.txt"
+    
+    with open(filename, 'a', encoding='utf-8') as f:
+        f.write(f"\n=== 벤치마크 결과 (회의 ID: {meeting_id}, 실행 {run_number}) ===\n")
+        
+        # 단일 서버 결과
+        f.write("\n[단일 서버]\n")
+        f.write(f"실행 시간: {single_result['duration']:.2f}초\n")
+        f.write(f"키워드: {', '.join(single_result['keywords'])}\n")
+        f.write(f"요약: {single_result['summary']}\n")
+        f.write(f"논문 수: {single_result['papers_count']}\n")
+        f.write(f"평균 관련도: {np.mean(single_result['relevance_scores']):.4f}\n")
+        
+        # 분산 서버 결과
+        f.write("\n[분산 서버]\n")
+        f.write(f"실행 시간: {dist_result[0]:.2f}초\n")
+        f.write(f"키워드: {', '.join(dist_result[1])}\n")
+        f.write(f"요약: {dist_result[2]}\n")
+        f.write(f"논문 수: {len(dist_result[4])}\n")
+        f.write(f"평균 관련도: {np.mean(dist_result[5]):.4f}\n")
+        
+        f.write("\n" + "="*50 + "\n")
+
+def analyze_results(results):
+    """결과 분석 및 시각화"""
+    # 데이터프레임 생성
+    single_df = pd.DataFrame(results['single'])
+    dist_df = pd.DataFrame(results['distributed'])
+    
+    # 기본 통계
+    print("\n=== 성능 분석 결과 ===")
+    print("\n단일 서버:")
+    print(single_df['duration'].describe())
+    print("\n분산 서버 (초기 응답):")
+    print(dist_df['duration'].describe())
+    
+    # 관련도 분석
+    print("\n=== 관련도 분석 결과 ===")
+    print("\n단일 서버 평균 관련도:", np.mean([np.mean(scores) for scores in single_df['relevance_scores']]))
+    print("분산 서버 평균 관련도:", np.mean([np.mean(scores) for scores in dist_df['relevance_scores']]))
+    
+    # 시각화
+    plt.figure(figsize=(15, 10))
+    
+    # 응답 시간 박스플롯
+    plt.subplot(2, 2, 1)
+    data = pd.DataFrame({
+        '단일 서버': single_df['duration'],
+        '분산 서버': dist_df['duration']
+    })
+    sns.boxplot(data=data)
+    plt.title('응답 시간 분포')
+    plt.ylabel('시간 (초)')
+    
+    # 평균 응답 시간 바플롯
+    plt.subplot(2, 2, 2)
+    means = pd.DataFrame({
+        '서버 유형': ['단일 서버', '분산 서버'],
+        '평균 응답 시간': [single_df['duration'].mean(), dist_df['duration'].mean()]
+    })
+    sns.barplot(data=means, x='서버 유형', y='평균 응답 시간')
+    plt.title('평균 응답 시간 비교')
+    
+    # 관련도 박스플롯
+    plt.subplot(2, 2, 3)
+    relevance_data = pd.DataFrame({
+        '단일 서버': [score for scores in single_df['relevance_scores'] for score in scores],
+        '분산 서버': [score for scores in dist_df['relevance_scores'] for score in scores]
+    })
+    sns.boxplot(data=relevance_data)
+    plt.title('관련도 분포')
+    plt.ylabel('관련도 점수')
+    
+    # 평균 관련도 바플롯
+    plt.subplot(2, 2, 4)
+    relevance_means = pd.DataFrame({
+        '서버 유형': ['단일 서버', '분산 서버'],
+        '평균 관련도': [
+            np.mean([np.mean(scores) for scores in single_df['relevance_scores']]),
+            np.mean([np.mean(scores) for scores in dist_df['relevance_scores']])
+        ]
+    })
+    sns.barplot(data=relevance_means, x='서버 유형', y='평균 관련도')
+    plt.title('평균 관련도 비교')
+    
+    plt.tight_layout()
+    plt.savefig('benchmark_results.png')
+    print("\n결과가 'benchmark_results.png'에 저장되었습니다.")
+
+if __name__ == "__main__":
+    # 테스트용 회의록 텍스트
+    meeting_text = """
+    [교수님] 음, 지난주에 이야기했던 리더 선출 알고리즘 논문 다 읽었죠? Raft랑 Viewstamped Replication 비교해봤을 때 우리 과제에는 뭐가 더 맞는 것 같아요?
+
+[석사1 민재] 저는 Raft가 구현하기엔 조금 더 직관적인 것 같습니다. 리더 선출 과정이 로그랑 연계돼 있어서 실험 설계하기 수월할 것 같고요.
+
+[학부연구생 혜진] 근데 Viewstamped Replication은 state transfer를 따로 처리하지 않아도 돼서, 복구 시나리오에선 오히려 안정적인 것 같았어요.
+
+[교수님] 그치, 그게 딱 핵심인데, 지금 우리가 처리하려는 상황은 장애 복구가 많은 분산 환경이잖아. 장애 빈도가 높으면 state transfer cost가 핵심이 되지. 두 방식 다 간단히 프로토타입 만들어보고 실험 돌려보는 게 어때?
+
+[석사2 윤석] 저희 지난 학기에 만든 클러스터 환경 그대로 써도 되겠죠? 총 5개 노드 띄우고, 하나씩 kill해서 리더 전환 시간 측정하는 방식으로요.
+
+[교수님] 좋아. 그럼 그 실험은 윤석 씨가 맡고, 혜진 씨는 Viewstamped Replication 프로토콜 구현 가능한지 검토해보고요. 코드베이스는 지난 분산 키밸류 저장소 코드 재활용하면 되니까. 민재 씨는 Raft 베이스로 정리해서 성능 비교 지표 준비하고요.
+
+[학부연구생 혜진] 아, 근데 그 코드에서 네트워크 딜레이는 어떻게 넣을까요? 지금은 다 localhost에서 돌리니까 의미가 잘 안 보일 것 같아요.
+
+[석사2 윤석] 저 그거 지난주에 tc 설정으로 시뮬레이션 한 번 해봤어요. 50ms 딜레이 넣으면 리더 전환 감지 시간이 확 늘어나더라고요. 실험 조건으로 잘 쓸 수 있을 것 같아요.
+
+[교수님] 오, 잘했네요. 그럼 딜레이도 변수로 넣어서 각 알고리즘이 딜레이에 얼마나 민감한지까지 확인해보죠. 결과는 다음 회의 때 공유하는 걸로 합시다.
+
+    """
+    
+    # 벤치마크 실행
+    results = run_benchmark(meeting_text, meeting_id=1, num_runs=2)
+    
+    # 결과 분석
+    analyze_results(results) 

--- a/gateway.py
+++ b/gateway.py
@@ -1,12 +1,18 @@
 import uuid
 import itertools
 from flask import Flask, request, jsonify
+from dotenv import load_dotenv
+import os
+
+# 환경변수 로드
+load_dotenv()
+
 from app.services.llm_service import extract_keywords
 from app.celery_app import celery_app
 
 app = Flask(__name__)
 
-@app.route('/api/meeting', methods=['POST'])
+@app.route('/api/papers/inference', methods=['POST'])
 def handle_meeting():
     data = request.json
     meeting_text = data['content']

--- a/gateway.py
+++ b/gateway.py
@@ -7,7 +7,7 @@ import os
 # 환경변수 로드
 load_dotenv()
 
-from app.services.llm_service import extract_keywords
+from app.services.llm_service import extract_keywords, translate_to_english
 from app.celery_app import celery_app
 
 app = Flask(__name__)
@@ -20,6 +20,9 @@ def handle_meeting():
 
     ks = extract_keywords(meeting_text)
     keywords = ks.keywords
+
+    # 회의록을 영어로 번역
+    meeting_text_en = translate_to_english(meeting_text)
 
     combos = []
     for r in range(2, len(keywords)+1):
@@ -35,7 +38,7 @@ def handle_meeting():
     # Reduce 태스크 비동기 발행
     celery_app.send_task(
         'workers.openalex_reduce_worker.reduce',
-        args=[task_id, len(combos), meeting_id]
+        args=[task_id, len(combos), meeting_id, meeting_text_en]
     )
 
     response = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ selenium==4.18.1
 python-dotenv==1.0.1
 redis==5.0.1
 celery==5.3.6
-openalex-python==0.1.0
 pydantic==2.6.3 

--- a/run.py
+++ b/run.py
@@ -1,6 +1,12 @@
+from dotenv import load_dotenv
+import os
+
+# .env 파일에서 환경변수 로드
+load_dotenv()
+
 from app import create_app
 
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5001, debug=True)
+    app.run(host="0.0.0.0", port=5002, debug=True)

--- a/start_celery_workers.sh
+++ b/start_celery_workers.sh
@@ -39,6 +39,10 @@ echo "Starting InvertedIndex Worker..."
 celery -A app.celery_app worker -Q invertedindex -n invertedindex_worker@%h -c 6 -l info > "logs/invertedindex_worker_${TIMESTAMP}.log" 2>&1 &
 echo $! >> "logs/worker_pids_${TIMESTAMP}.txt"
 
+echo "Starting Relevance Worker..."
+celery -A app.celery_app worker -Q relevance -n relevance_worker@%h -c 4 -l info > "logs/relevance_worker_${TIMESTAMP}.log" 2>&1 &
+echo $! >> "logs/worker_pids_${TIMESTAMP}.txt"
+
 echo "Starting Flower..."
 celery -A app.celery_app flower --port=5555 > "logs/flower_${TIMESTAMP}.log" 2>&1 &
 echo "flower=$!" >> "logs/worker_pids_${TIMESTAMP}.txt"

--- a/start_celery_workers.sh
+++ b/start_celery_workers.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# 로그 디렉토리 생성
+mkdir -p logs
+
+# 타임스탬프 생성
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+
+# 환경변수 로드
+if [ -f .env ]; then
+    export $(cat .env | grep -v '^#' | xargs)
+else
+    echo "Error: .env file not found"
+    exit 1
+fi
+
+# PDF Worker (4개 프로세스)
+echo "Starting PDF Worker..."
+celery -A app.celery_app worker -Q pdf -n pdf_worker@%h -c 4 -l info > "logs/pdf_worker_${TIMESTAMP}.log" 2>&1 &
+echo $! > "logs/worker_pids_${TIMESTAMP}.txt"
+
+# LLM Worker (2개 프로세스 - API 제한 고려)
+echo "Starting LLM Worker..."
+celery -A app.celery_app worker -Q llm -n llm_worker@%h -c 3 -l info > "logs/llm_worker_${TIMESTAMP}.log" 2>&1 &
+echo $! >> "logs/worker_pids_${TIMESTAMP}.txt"
+
+# OpenAlex Worker (4개 프로세스)
+echo "Starting OpenAlex Worker..."
+celery -A app.celery_app worker -Q openalex -n openalex_worker@%h -c 4 -l info > "logs/openalex_worker_${TIMESTAMP}.log" 2>&1 &
+echo $! >> "logs/worker_pids_${TIMESTAMP}.txt"
+
+# Reduce OpenAlex Worker (2개 프로세스)
+echo "Starting Reduce OpenAlex Worker..."
+celery -A app.celery_app worker -Q reduce_openalex -n reduce_openalex_worker@%h -c 2 -l info > "logs/reduce_openalex_worker_${TIMESTAMP}.log" 2>&1 &
+echo $! >> "logs/worker_pids_${TIMESTAMP}.txt"
+
+# InvertedIndex Worker (4개 프로세스)
+echo "Starting InvertedIndex Worker..."
+celery -A app.celery_app worker -Q invertedindex -n invertedindex_worker@%h -c 6 -l info > "logs/invertedindex_worker_${TIMESTAMP}.log" 2>&1 &
+echo $! >> "logs/worker_pids_${TIMESTAMP}.txt"
+
+echo "Starting Flower..."
+celery -A app.celery_app flower --port=5555 > "logs/flower_${TIMESTAMP}.log" 2>&1 &
+echo "flower=$!" >> "logs/worker_pids_${TIMESTAMP}.txt"
+
+echo "All workers started. Logs are in the logs directory."
+echo "To stop workers, use: ./stop_celery_workers.sh ${TIMESTAMP}"

--- a/stop_celery_workers.sh
+++ b/stop_celery_workers.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: ./stop_celery_workers.sh <timestamp>"
+    echo "Example: ./stop_celery_workers.sh 20240601_023016"
+    exit 1
+fi
+
+TIMESTAMP=$1
+PID_FILE="logs/worker_pids_${TIMESTAMP}.txt"
+
+if [ ! -f "$PID_FILE" ]; then
+    echo "Error: PID file not found: $PID_FILE"
+    exit 1
+fi
+
+# PID 파일에서 각 워커의 PID를 읽어서 종료
+while IFS='=' read -r name pid; do
+    if [ -n "$pid" ]; then
+        echo "Stopping $name (PID: $pid)..."
+        kill $pid 2>/dev/null || echo "Process $pid not found"
+    fi
+done < "$PID_FILE"
+
+# 로그 파일 정리
+echo "Cleaning up log files..."
+rm -f "logs/pdf_worker_${TIMESTAMP}.log"
+rm -f "logs/llm_worker_${TIMESTAMP}.log"
+rm -f "logs/openalex_worker_${TIMESTAMP}.log"
+rm -f "logs/reduce_openalex_worker_${TIMESTAMP}.log"
+rm -f "logs/invertedindex_worker_${TIMESTAMP}.log"
+rm -f "logs/flower_${TIMESTAMP}.log"
+rm -f "$PID_FILE"
+
+# logs 디렉토리가 비어있으면 삭제
+if [ -z "$(ls -A logs 2>/dev/null)" ]; then
+    rmdir logs
+    echo "Removed empty logs directory"
+fi
+
+echo "All workers stopped and log files cleaned up." 

--- a/stop_celery_workers.sh
+++ b/stop_celery_workers.sh
@@ -22,6 +22,8 @@ while IFS='=' read -r name pid; do
     fi
 done < "$PID_FILE"
 
+pkill -9 -f 'celery'
+
 # 로그 파일 정리
 echo "Cleaning up log files..."
 rm -f "logs/pdf_worker_${TIMESTAMP}.log"
@@ -29,6 +31,7 @@ rm -f "logs/llm_worker_${TIMESTAMP}.log"
 rm -f "logs/openalex_worker_${TIMESTAMP}.log"
 rm -f "logs/reduce_openalex_worker_${TIMESTAMP}.log"
 rm -f "logs/invertedindex_worker_${TIMESTAMP}.log"
+rm -f "logs/relevance_worker_${TIMESTAMP}.log"
 rm -f "logs/flower_${TIMESTAMP}.log"
 rm -f "$PID_FILE"
 


### PR DESCRIPTION
**코드 수정사항**
1. 관련도 알고리즘이 빈약한 것 같아 **TF-IDF 코사인 유사도**를 도입했습니다. 해당 유사도를 측정하기 위해서는 영어-영어 또는 한글-한글끼리 비교해야 하므로 회의록을 gateway.py에서 gemini를 통해 번역하는 과정이 추가되었습니다.

해당 알고리즘의 자세한 동작 원리는 다음 글을 참고해주세요. [코사인 유사도(Cosine Similarity)](https://wikidocs.net/24603)

2. 기존 openalex worker에서 MapReduce 알고리즘에서는 상위 10개가 아닌 상위 20개로 늘리고 relevance worker를 도입하여 해당 worker가 전체 20개의 논문들 중에서 유사도가 높은 상위 10개의 논문들을 뽑아 llm worker에게 요약 요청을 날리도록 했습니다.

이 과정에서 relevance worker에서 20개의 논문을 모두 기다리기 때문에 심한 병목현상이 발생하는 것을 확인해서 이를 해결하기 위해 2가지 해결방안을 도입했습니다.
a. 논문을 5개씩 chunk 단위로 잘라서 해결 -> pdf worker에서 텍스트를 추출완료하여 relevance worker에게 이벤트 요청을 보낼때 5개의 논문이 도착했다면 5개 중에 상위 관련 논문 3개를 골라 llm worker에게 요약 요청을 보냅니다. 이후에도 5개 단위로 요청이 들어오면 남아있던 논문을 포함해서 유사도를 측정한 후 3개씩 llm worker를 보내는 방식입니다.
b. 병렬 프로세스를 도입 -> 각 프로세스가 2개씩의 논문 유사도를 계산하도록하고 마지막에 해당 유사도를 합쳐서 정렬하여 한번 계산시에도 최대한 성능을 높이고자 했습니다.

**벤치마킹 결과**
생각보다 많이 유의미한 결과가 나와서 놀랐습니다. 직접 돌려보시면 아시겠지만 벤치마킹이 종료되면 다음과 같이 단일 서버와 분산서버의 성능 지표를 그래프로 표시하도록 했습니다. 현재 8번정도 같은 입력값을 주었을 때의 평균치를 낸 결과인데, 성능 / 관련도 두가지 면 모두 분산서버가 우수한 것을 확인할 수 있었습니다!
<img width="1138" alt="스크린샷 2025-06-05 오전 3 51 25" src="https://github.com/user-attachments/assets/a06622f3-32d2-483a-a2cc-3d90ea2cd450" />

벤치마킹 방법은 [노션](https://honored-yellowhorn-89c.notion.site/20876fc828e48066875bfd424b5ccdb0?source=copy_link)에 정리해두었으니 실행시에 확인해주시면 감사하겠습니다. (실행시에 노션에 정리해둔 .env 파일 만드는 것도 잊지 말아주세요!)